### PR TITLE
Add a script to group by season and team for advanced stats

### DIFF
--- a/advanced_stats_starter.py
+++ b/advanced_stats_starter.py
@@ -8,12 +8,6 @@ pd.set_option('display.max_rows', 500)
 pd.set_option('display.max_columns', 500)
 pd.set_option('display.width', 1000)
 
-submission = pd.read_csv("input/SampleSubmissionStage1.csv")
-# playoff_results = pd.read_csv("input/NCAATourneyDetailedResults.csv")
-compact_playoff_results = pd.read_csv("input/NCAATourneyCompactResults.csv")
-playoff_seeds = pd.read_csv("input/NCAATourneySeeds.csv")
-seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
-seasons_results.drop(['NumOT', 'DayNum'], axis=1, inplace=True)
 
 # https://www.basketball-reference.com/about/glossary.html
 def get_pos(row):
@@ -21,127 +15,43 @@ def get_pos(row):
     l_half = row.LFGA + 0.4*row.LFTA - 1.07*(row.LOR / (row.LOR + row.WDR))*(row.LFGA - row.LFGM) + row.LTO
     return 0.5*(w_half+l_half)
 
+def get_four_factor(row):
+    # Shooting the ball
+    efg = (row.WFGM + 0.5 * row.WFGM3) / row.WFGA
 
-def seed_to_int(seed):
-    #Get just the digits from the seeding. Return as int
-    s_int = int(seed[1:3])
-    return s_int
+    # Taking care of the ball
+    turnover_rate = row.WTO / (row.WFGA + 0.44 * row.WFTA + row.WTO)
 
-win_stats = ['WTeamID', 'WScore', 'WFGM', 'WFGA', 'WFGM3', 'WFGA3', 'WFTM', 'WFTA', 'WOR', 'WDR', 'WAst', 'WTO', 'WStl', 'WBlk', 'WPF']
-lose_stats = ['LTeamID', 'LScore', 'LFGM', 'LFGA', 'LFGM3', 'LFGA3', 'LFTM', 'LFTA', 'LOR', 'LDR', 'LAst', 'LTO', 'LStl', 'LBlk', 'LPF']
+    # Offensive rebounding
+    offensive_rebounding_percentage = row.WOR / (row.WOR + row.LDR)
 
-seasons_results_copy = seasons_results.copy()
-seasons_results_copy[win_stats + lose_stats] = seasons_results_copy[lose_stats + win_stats]
+    # Free throw rate
+    free_throw_rate = row.WFTM / row.WFGA
 
-seasons_results = pd.concat([seasons_results, seasons_results_copy], ignore_index=True)
-
-adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID']).sum().reset_index()
-adv_stat_team_season['Pos'] = adv_stat_team_season.apply(get_pos, axis=1)
-adv_stat_team_season['ORating'] = adv_stat_team_season.apply(lambda row: 100*row.WScore/row.Pos, axis=1)
-adv_stat_team_season['DRating'] = adv_stat_team_season.apply(lambda row: 100*row.LScore/row.Pos, axis=1)
-adv_stat_team_season = adv_stat_team_season.drop(['LTeamID'], axis=1)
-adv_stat_team_season = adv_stat_team_season.rename(columns={'WTeamID': 'TeamID'})
-
-# lets use data from 2003-2013 to train the modal
-train = compact_playoff_results.loc[(compact_playoff_results['Season'] >= 2003) & (compact_playoff_results['Season'] <= 2013)]
-train = train.drop(['DayNum', 'WScore', 'LScore', 'WLoc', 'NumOT'], axis=1)
-
-train_stats = ['Season', 'TeamID', 'ORating', 'DRating']
-win_adv_stats = adv_stat_team_season[train_stats].rename(columns={'TeamID': 'WTeamID', 'ORating': 'WORating', 'DRating': 'WDRating'})
-lose_adv_stats = adv_stat_team_season[train_stats].rename(columns={'TeamID': 'LTeamID', 'ORating': 'LORating', 'DRating': 'LDRating'})
-train = train.merge(win_adv_stats, on=['Season', 'WTeamID'])
-train = train.merge(lose_adv_stats, on=['Season', 'LTeamID'])
-
-playoff_seeds['seed_int'] = playoff_seeds.Seed.apply(seed_to_int)
-playoff_seeds['seed_int'] = playoff_seeds['seed_int'].abs()
-playoff_seeds.drop('Seed', inplace=True, axis=1)
-
-winseeds = playoff_seeds.rename(columns={'TeamID': 'WTeamID', 'seed_int': 'WSeed'})
-lossseeds = playoff_seeds.rename(columns={'TeamID': 'LTeamID', 'seed_int': 'LSeed'})
-
-train = train.merge(winseeds, on=['Season', 'WTeamID'])
-train = train.merge(lossseeds, on=['Season', 'LTeamID'])
-train['SeedDiff'] = train.WSeed - train.LSeed
-train = train.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
-train['Result'] = 1
-
-train_copy = train.copy()
-
-train_w_stat = ['WORating', 'WDRating', 'WSeed']
-train_l_stat = ['LORating', 'LDRating', 'LSeed']
-
-train_copy[train_w_stat + train_l_stat] = train_copy[train_l_stat + train_w_stat]
-train_copy['Result'] = 0
-
-train = pd.concat([train, train_copy], ignore_index=True)
-
-y_train = train['Result'].values
-X_train = train.drop('Result', axis=1)
-
-logreg = LogisticRegression()
-params = {'C': np.logspace(start=-5, stop=3, num=9)}
-clf = GridSearchCV(logreg, params, scoring='neg_log_loss', refit=True)
-clf.fit(X_train, y_train)
-print('Best log_loss: {:.4}, with best C: {}'.format(clf.best_score_, clf.best_params_['C']))
+    return 0.4 * efg + 0.25 + turnover_rate + 0.2 * offensive_rebounding_percentage + 0.15 * free_throw_rate
 
 
+def get_adv_season_stats():
+    seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
+    seasons_results.drop(['NumOT', 'DayNum'], axis=1, inplace=True)
 
+    win_stats = ['WTeamID', 'WScore', 'WFGM', 'WFGA', 'WFGM3', 'WFGA3', 'WFTM', 'WFTA', 'WOR', 'WDR', 'WAst', 'WTO', 'WStl', 'WBlk', 'WPF']
+    lose_stats = ['LTeamID', 'LScore', 'LFGM', 'LFGA', 'LFGM3', 'LFGA3', 'LFTM', 'LFTA', 'LOR', 'LDR', 'LAst', 'LTO', 'LStl', 'LBlk', 'LPF']
 
-# creating test data
-prediction = pd.DataFrame()
-prediction['Season'] = submission['ID'].str[:4].astype(int)
-prediction['WTeamID'] = submission['ID'].str[5:9].astype(int)
-prediction['LTeamID'] = submission['ID'].str[10:].astype(int)
+    seasons_results_copy = seasons_results.copy()
+    seasons_results_copy[win_stats + lose_stats] = seasons_results_copy[lose_stats + win_stats]
 
-# note merging LTeamID first then WTeamID so that the order is WTeamID ascending, same order as the submission
-prediction = prediction.merge(lose_adv_stats, on=['Season', 'LTeamID'])
-prediction = prediction.merge(win_adv_stats, on=['Season', 'WTeamID'])
+    seasons_results = pd.concat([seasons_results, seasons_results_copy], ignore_index=True)
 
-prediction = prediction.merge(lossseeds, on=['Season', 'LTeamID'])
-prediction = prediction.merge(winseeds, on=['Season', 'WTeamID'])
-prediction['SeedDiff'] = prediction.WSeed - prediction.LSeed
-prediction = prediction.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
+    adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID']).sum().reset_index()
+    adv_stat_team_season['Pos'] = adv_stat_team_season.apply(get_pos, axis=1)
+    adv_stat_team_season['ORating'] = adv_stat_team_season.apply(lambda row: 100*row.WScore/row.Pos, axis=1)
+    adv_stat_team_season['DRating'] = adv_stat_team_season.apply(lambda row: 100*row.LScore/row.Pos, axis=1)
+    adv_stat_team_season['NRating'] = adv_stat_team_season['ORating'] - adv_stat_team_season['DRating']
+    adv_stat_team_season['FourFactors'] = adv_stat_team_season.apply(get_four_factor, axis=1)
+    adv_stat_team_season = adv_stat_team_season.drop(['LTeamID'], axis=1)
+    adv_stat_team_season = adv_stat_team_season.rename(columns={'WTeamID': 'TeamID'})
 
-submission['Pred'] = clf.predict_proba(prediction)
+    return adv_stat_team_season
 
-print(submission.head())
-
-# submission.to_csv('logreg_seed_starter.csv', index=False)
-
-# create a local function to meausre the logloss so don't have submit every time
-val_start_year = 2014
-val_end_year = 2017
-
-val_results = compact_playoff_results.loc[(compact_playoff_results['Season'] >= val_start_year) & (compact_playoff_results['Season'] <= val_end_year)]
-val_results = val_results.loc[val_results['DayNum'] >= 136]
-val_results = val_results.drop(['DayNum', 'WScore', 'LScore', 'WLoc', 'NumOT'], axis=1)
-
-
-def create_id(row):
-    row_id = str(row.Season) + '_'
-
-    if row.WTeamID < row.LTeamID:
-        row_id = row_id + str(row.WTeamID) + '_' + str(row.LTeamID)
-    else:
-        row_id = row_id + str(row.LTeamID) + '_' + str(row.WTeamID)
-
-    return row_id
-
-
-def get_result(row):
-    if row.WTeamID < row.LTeamID:
-        return 1
-    else:
-        return 0
-
-val_results['ID'] = val_results.apply(create_id, axis=1)
-val_results['Result'] = val_results.apply(get_result, axis=1)
-val_results = val_results.drop(['WTeamID', 'LTeamID'], axis=1)
-
-final_comparison = submission.merge(val_results, on='ID')
-
-print('final log loss: ', metrics.log_loss(final_comparison['Result'], final_comparison['Pred']))
-
-for target_season in final_comparison.Season.unique():
-    temp = final_comparison[ final_comparison['Season'] == target_season]
-    print('Season ', target_season, ' log loss: ', metrics.log_loss(temp['Result'], temp['Pred']))
+print(get_adv_season_stats().head())

--- a/advanced_stats_starter.py
+++ b/advanced_stats_starter.py
@@ -1,20 +1,31 @@
 import pandas as pd
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV
+import sklearn.metrics as metrics
 
 pd.set_option('display.max_rows', 500)
 pd.set_option('display.max_columns', 500)
 pd.set_option('display.width', 1000)
 
 submission = pd.read_csv("input/SampleSubmissionStage1.csv")
-playoff_results = pd.read_csv("input/NCAATourneyDetailedResults.csv")
+# playoff_results = pd.read_csv("input/NCAATourneyDetailedResults.csv")
+compact_playoff_results = pd.read_csv("input/NCAATourneyCompactResults.csv")
+playoff_seeds = pd.read_csv("input/NCAATourneySeeds.csv")
 seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
 seasons_results.drop(['NumOT', 'DayNum'], axis=1, inplace=True)
-
 
 # https://www.basketball-reference.com/about/glossary.html
 def get_pos(row):
     w_half = row.WFGA + 0.4*row.WFTA - 1.07*(row.WOR / (row.WOR + row.LDR))*(row.WFGA - row.WFGM) + row.WTO
     l_half = row.LFGA + 0.4*row.LFTA - 1.07*(row.LOR / (row.LOR + row.WDR))*(row.LFGA - row.LFGM) + row.LTO
     return 0.5*(w_half+l_half)
+
+
+def seed_to_int(seed):
+    #Get just the digits from the seeding. Return as int
+    s_int = int(seed[1:3])
+    return s_int
 
 win_stats = ['WTeamID', 'WScore', 'WFGM', 'WFGA', 'WFGM3', 'WFGA3', 'WFTM', 'WFTA', 'WOR', 'WDR', 'WAst', 'WTO', 'WStl', 'WBlk', 'WPF']
 lose_stats = ['LTeamID', 'LScore', 'LFGM', 'LFGA', 'LFGM3', 'LFGA3', 'LFTM', 'LFTA', 'LOR', 'LDR', 'LAst', 'LTO', 'LStl', 'LBlk', 'LPF']
@@ -24,9 +35,113 @@ seasons_results_copy[win_stats + lose_stats] = seasons_results_copy[lose_stats +
 
 seasons_results = pd.concat([seasons_results, seasons_results_copy], ignore_index=True)
 
-adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID']).sum()
-adv_stat_team_season['Pos'] = adv_stat_team_season.apply(lambda row: get_pos(row), axis=1)
+adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID']).sum().reset_index()
+adv_stat_team_season['Pos'] = adv_stat_team_season.apply(get_pos, axis=1)
 adv_stat_team_season['ORating'] = adv_stat_team_season.apply(lambda row: 100*row.WScore/row.Pos, axis=1)
 adv_stat_team_season['DRating'] = adv_stat_team_season.apply(lambda row: 100*row.LScore/row.Pos, axis=1)
-print(adv_stat_team_season.head())
+adv_stat_team_season = adv_stat_team_season.drop(['LTeamID'], axis=1)
+adv_stat_team_season = adv_stat_team_season.rename(columns={'WTeamID': 'TeamID'})
 
+# lets use data from 2003-2013 to train the modal
+train = compact_playoff_results.loc[(compact_playoff_results['Season'] >= 2003) & (compact_playoff_results['Season'] <= 2013)]
+train = train.drop(['DayNum', 'WScore', 'LScore', 'WLoc', 'NumOT'], axis=1)
+
+train_stats = ['Season', 'TeamID', 'ORating', 'DRating']
+win_adv_stats = adv_stat_team_season[train_stats].rename(columns={'TeamID': 'WTeamID', 'ORating': 'WORating', 'DRating': 'WDRating'})
+lose_adv_stats = adv_stat_team_season[train_stats].rename(columns={'TeamID': 'LTeamID', 'ORating': 'LORating', 'DRating': 'LDRating'})
+train = train.merge(win_adv_stats, on=['Season', 'WTeamID'])
+train = train.merge(lose_adv_stats, on=['Season', 'LTeamID'])
+
+playoff_seeds['seed_int'] = playoff_seeds.Seed.apply(seed_to_int)
+playoff_seeds['seed_int'] = playoff_seeds['seed_int'].abs()
+playoff_seeds.drop('Seed', inplace=True, axis=1)
+
+winseeds = playoff_seeds.rename(columns={'TeamID': 'WTeamID', 'seed_int': 'WSeed'})
+lossseeds = playoff_seeds.rename(columns={'TeamID': 'LTeamID', 'seed_int': 'LSeed'})
+
+train = train.merge(winseeds, on=['Season', 'WTeamID'])
+train = train.merge(lossseeds, on=['Season', 'LTeamID'])
+train['SeedDiff'] = train.WSeed - train.LSeed
+train = train.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
+train['Result'] = 1
+
+train_copy = train.copy()
+
+train_w_stat = ['WORating', 'WDRating', 'WSeed']
+train_l_stat = ['LORating', 'LDRating', 'LSeed']
+
+train_copy[train_w_stat + train_l_stat] = train_copy[train_l_stat + train_w_stat]
+train_copy['Result'] = 0
+
+train = pd.concat([train, train_copy], ignore_index=True)
+
+y_train = train['Result'].values
+X_train = train.drop('Result', axis=1)
+
+logreg = LogisticRegression()
+params = {'C': np.logspace(start=-5, stop=3, num=9)}
+clf = GridSearchCV(logreg, params, scoring='neg_log_loss', refit=True)
+clf.fit(X_train, y_train)
+print('Best log_loss: {:.4}, with best C: {}'.format(clf.best_score_, clf.best_params_['C']))
+
+
+
+
+# creating test data
+prediction = pd.DataFrame()
+prediction['Season'] = submission['ID'].str[:4].astype(int)
+prediction['WTeamID'] = submission['ID'].str[5:9].astype(int)
+prediction['LTeamID'] = submission['ID'].str[10:].astype(int)
+
+# note merging LTeamID first then WTeamID so that the order is WTeamID ascending, same order as the submission
+prediction = prediction.merge(lose_adv_stats, on=['Season', 'LTeamID'])
+prediction = prediction.merge(win_adv_stats, on=['Season', 'WTeamID'])
+
+prediction = prediction.merge(lossseeds, on=['Season', 'LTeamID'])
+prediction = prediction.merge(winseeds, on=['Season', 'WTeamID'])
+prediction['SeedDiff'] = prediction.WSeed - prediction.LSeed
+prediction = prediction.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
+
+submission['Pred'] = clf.predict_proba(prediction)
+
+print(submission.head())
+
+# submission.to_csv('logreg_seed_starter.csv', index=False)
+
+# create a local function to meausre the logloss so don't have submit every time
+val_start_year = 2014
+val_end_year = 2017
+
+val_results = compact_playoff_results.loc[(compact_playoff_results['Season'] >= val_start_year) & (compact_playoff_results['Season'] <= val_end_year)]
+val_results = val_results.loc[val_results['DayNum'] >= 136]
+val_results = val_results.drop(['DayNum', 'WScore', 'LScore', 'WLoc', 'NumOT'], axis=1)
+
+
+def create_id(row):
+    row_id = str(row.Season) + '_'
+
+    if row.WTeamID < row.LTeamID:
+        row_id = row_id + str(row.WTeamID) + '_' + str(row.LTeamID)
+    else:
+        row_id = row_id + str(row.LTeamID) + '_' + str(row.WTeamID)
+
+    return row_id
+
+
+def get_result(row):
+    if row.WTeamID < row.LTeamID:
+        return 1
+    else:
+        return 0
+
+val_results['ID'] = val_results.apply(create_id, axis=1)
+val_results['Result'] = val_results.apply(get_result, axis=1)
+val_results = val_results.drop(['WTeamID', 'LTeamID'], axis=1)
+
+final_comparison = submission.merge(val_results, on='ID')
+
+print('final log loss: ', metrics.log_loss(final_comparison['Result'], final_comparison['Pred']))
+
+for target_season in final_comparison.Season.unique():
+    temp = final_comparison[ final_comparison['Season'] == target_season]
+    print('Season ', target_season, ' log loss: ', metrics.log_loss(temp['Result'], temp['Pred']))

--- a/advanced_stats_starter.py
+++ b/advanced_stats_starter.py
@@ -7,26 +7,26 @@ pd.set_option('display.width', 1000)
 submission = pd.read_csv("input/SampleSubmissionStage1.csv")
 playoff_results = pd.read_csv("input/NCAATourneyDetailedResults.csv")
 seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
+seasons_results.drop(['NumOT', 'DayNum'], axis=1, inplace=True)
 
 
 # https://www.basketball-reference.com/about/glossary.html
 def get_pos(row):
-    w_half = row.WFGA + 0.4*row.WFTA - 1.07*(row.WOR / (row.WOR + row.LOR))*(row.WFGA - row.WFGM) + row.WTO
-    l_half = row.LFGA + 0.4*row.LFTA - 1.07*(row.LOR / (row.LOR + row.WOR))*(row.LFGA - row.LFGM) + row.LTO
+    w_half = row.WFGA + 0.4*row.WFTA - 1.07*(row.WOR / (row.WOR + row.LDR))*(row.WFGA - row.WFGM) + row.WTO
+    l_half = row.LFGA + 0.4*row.LFTA - 1.07*(row.LOR / (row.LOR + row.WDR))*(row.LFGA - row.LFGM) + row.LTO
     return 0.5*(w_half+l_half)
 
-seasons_results['Pos'] = seasons_results.apply(lambda row: get_pos(row), axis=1)
+win_stats = ['WTeamID', 'WScore', 'WFGM', 'WFGA', 'WFGM3', 'WFGA3', 'WFTM', 'WFTA', 'WOR', 'WDR', 'WAst', 'WTO', 'WStl', 'WBlk', 'WPF']
+lose_stats = ['LTeamID', 'LScore', 'LFGM', 'LFGA', 'LFGM3', 'LFGA3', 'LFTM', 'LFTA', 'LOR', 'LDR', 'LAst', 'LTO', 'LStl', 'LBlk', 'LPF']
 
-seasons_results_cpy = seasons_results.copy()
-seasons_results_cpy[['WTeamID', 'WScore', 'LTeamID', 'LScore']] = seasons_results_cpy[['LTeamID', 'LScore', 'WTeamID', 'WScore']]
+seasons_results_copy = seasons_results.copy()
+seasons_results_copy[win_stats + lose_stats] = seasons_results_copy[lose_stats + win_stats]
 
-seasons_results = pd.concat([seasons_results, seasons_results_cpy], ignore_index=True)
+seasons_results = pd.concat([seasons_results, seasons_results_copy], ignore_index=True)
 
-adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID'])['Pos', 'WScore', 'LScore'].sum()
-# pos_team_season = season_games.groupby(['Season', 'WTeamID']).size().reset_index(name='count')
+adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID']).sum()
+adv_stat_team_season['Pos'] = adv_stat_team_season.apply(lambda row: get_pos(row), axis=1)
 adv_stat_team_season['ORating'] = adv_stat_team_season.apply(lambda row: 100*row.WScore/row.Pos, axis=1)
 adv_stat_team_season['DRating'] = adv_stat_team_season.apply(lambda row: 100*row.LScore/row.Pos, axis=1)
-adv_stat_team_season = adv_stat_team_season.reset_index()
-
-adv_stat_team_season.drop('Pos', axis=1, inplace=True)
 print(adv_stat_team_season.head())
+

--- a/advanced_stats_starter.py
+++ b/advanced_stats_starter.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+pd.set_option('display.max_rows', 500)
+pd.set_option('display.max_columns', 500)
+pd.set_option('display.width', 1000)
+
+submission = pd.read_csv("input/SampleSubmissionStage1.csv")
+playoff_results = pd.read_csv("input/NCAATourneyDetailedResults.csv")
+seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
+
+
+# https://www.basketball-reference.com/about/glossary.html
+def get_pos(row):
+    w_half = row.WFGA + 0.4*row.WFTA - 1.07*(row.WOR / (row.WOR + row.LOR))*(row.WFGA - row.WFGM) + row.WTO
+    l_half = row.LFGA + 0.4*row.LFTA - 1.07*(row.LOR / (row.LOR + row.WOR))*(row.LFGA - row.LFGM) + row.LTO
+    return 0.5*(w_half+l_half)
+
+seasons_results['Pos'] = seasons_results.apply(lambda row: get_pos(row), axis=1)
+
+seasons_results_cpy = seasons_results.copy()
+seasons_results_cpy[['WTeamID', 'WScore', 'LTeamID', 'LScore']] = seasons_results_cpy[['LTeamID', 'LScore', 'WTeamID', 'WScore']]
+
+seasons_results = pd.concat([seasons_results, seasons_results_cpy], ignore_index=True)
+
+adv_stat_team_season = seasons_results.groupby(['Season', 'WTeamID'])['Pos', 'WScore', 'LScore'].sum()
+# pos_team_season = season_games.groupby(['Season', 'WTeamID']).size().reset_index(name='count')
+adv_stat_team_season['ORating'] = adv_stat_team_season.apply(lambda row: 100*row.WScore/row.Pos, axis=1)
+adv_stat_team_season['DRating'] = adv_stat_team_season.apply(lambda row: 100*row.LScore/row.Pos, axis=1)
+adv_stat_team_season = adv_stat_team_season.reset_index()
+
+adv_stat_team_season.drop('Pos', axis=1, inplace=True)
+print(adv_stat_team_season.head())

--- a/simple_logistric_regression.py
+++ b/simple_logistric_regression.py
@@ -1,0 +1,124 @@
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV
+from advanced_stats_starter import get_adv_season_stats
+import sklearn.metrics as metrics
+
+pd.set_option('display.max_rows', 500)
+pd.set_option('display.max_columns', 500)
+pd.set_option('display.width', 1000)
+
+submission = pd.read_csv("input/SampleSubmissionStage1.csv")
+# playoff_results = pd.read_csv("input/NCAATourneyDetailedResults.csv")
+compact_playoff_results = pd.read_csv("input/NCAATourneyCompactResults.csv")
+playoff_seeds = pd.read_csv("input/NCAATourneySeeds.csv")
+seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
+adv_stat_team_season = get_adv_season_stats()
+
+def seed_to_int(seed):
+    #Get just the digits from the seeding. Return as int
+    s_int = int(seed[1:3])
+    return s_int
+
+# lets use data from 2003-2013 to train the modal
+train = compact_playoff_results.loc[(compact_playoff_results['Season'] >= 2003) & (compact_playoff_results['Season'] <= 2013)]
+train = train.drop(['DayNum', 'WScore', 'LScore', 'WLoc', 'NumOT'], axis=1)
+
+train_stats = ['Season', 'TeamID', 'ORating', 'DRating']
+win_adv_stats = adv_stat_team_season[train_stats].rename(columns={'TeamID': 'WTeamID', 'ORating': 'WORating', 'DRating': 'WDRating'})
+lose_adv_stats = adv_stat_team_season[train_stats].rename(columns={'TeamID': 'LTeamID', 'ORating': 'LORating', 'DRating': 'LDRating'})
+train = train.merge(win_adv_stats, on=['Season', 'WTeamID'])
+train = train.merge(lose_adv_stats, on=['Season', 'LTeamID'])
+
+playoff_seeds['seed_int'] = playoff_seeds.Seed.apply(seed_to_int)
+playoff_seeds['seed_int'] = playoff_seeds['seed_int'].abs()
+playoff_seeds.drop('Seed', inplace=True, axis=1)
+
+winseeds = playoff_seeds.rename(columns={'TeamID': 'WTeamID', 'seed_int': 'WSeed'})
+lossseeds = playoff_seeds.rename(columns={'TeamID': 'LTeamID', 'seed_int': 'LSeed'})
+
+train = train.merge(winseeds, on=['Season', 'WTeamID'])
+train = train.merge(lossseeds, on=['Season', 'LTeamID'])
+train['SeedDiff'] = train.WSeed - train.LSeed
+train = train.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
+train['Result'] = 1
+
+train_copy = train.copy()
+
+train_w_stat = ['WORating', 'WDRating', 'WSeed']
+train_l_stat = ['LORating', 'LDRating', 'LSeed']
+
+train_copy[train_w_stat + train_l_stat] = train_copy[train_l_stat + train_w_stat]
+train_copy['Result'] = 0
+
+train = pd.concat([train, train_copy], ignore_index=True)
+
+y_train = train['Result'].values
+X_train = train.drop('Result', axis=1)
+
+logreg = LogisticRegression()
+params = {'C': np.logspace(start=-5, stop=3, num=9)}
+clf = GridSearchCV(logreg, params, scoring='neg_log_loss', refit=True)
+clf.fit(X_train, y_train)
+print('Best log_loss: {:.4}, with best C: {}'.format(clf.best_score_, clf.best_params_['C']))
+
+
+# creating test data
+prediction = pd.DataFrame()
+prediction['Season'] = submission['ID'].str[:4].astype(int)
+prediction['WTeamID'] = submission['ID'].str[5:9].astype(int)
+prediction['LTeamID'] = submission['ID'].str[10:].astype(int)
+
+# note merging LTeamID first then WTeamID so that the order is WTeamID ascending, same order as the submission
+prediction = prediction.merge(lose_adv_stats, on=['Season', 'LTeamID'])
+prediction = prediction.merge(win_adv_stats, on=['Season', 'WTeamID'])
+
+prediction = prediction.merge(lossseeds, on=['Season', 'LTeamID'])
+prediction = prediction.merge(winseeds, on=['Season', 'WTeamID'])
+prediction['SeedDiff'] = prediction.WSeed - prediction.LSeed
+prediction = prediction.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
+
+submission['Pred'] = clf.predict_proba(prediction)
+
+print(submission.head())
+
+# submission.to_csv('logreg_seed_starter.csv', index=False)
+
+# create a local function to meausre the logloss so don't have submit every time
+val_start_year = 2014
+val_end_year = 2017
+
+val_results = compact_playoff_results.loc[(compact_playoff_results['Season'] >= val_start_year) & (compact_playoff_results['Season'] <= val_end_year)]
+val_results = val_results.loc[val_results['DayNum'] >= 136]
+val_results = val_results.drop(['DayNum', 'WScore', 'LScore', 'WLoc', 'NumOT'], axis=1)
+
+
+def create_id(row):
+    row_id = str(row.Season) + '_'
+
+    if row.WTeamID < row.LTeamID:
+        row_id = row_id + str(row.WTeamID) + '_' + str(row.LTeamID)
+    else:
+        row_id = row_id + str(row.LTeamID) + '_' + str(row.WTeamID)
+
+    return row_id
+
+
+def get_result(row):
+    if row.WTeamID < row.LTeamID:
+        return 1
+    else:
+        return 0
+
+val_results['ID'] = val_results.apply(create_id, axis=1)
+val_results['Result'] = val_results.apply(get_result, axis=1)
+val_results = val_results.drop(['WTeamID', 'LTeamID'], axis=1)
+
+final_comparison = submission.merge(val_results, on='ID')
+
+print('final log loss: ', metrics.log_loss(final_comparison['Result'], final_comparison['Pred']))
+
+for target_season in final_comparison.Season.unique():
+    temp = final_comparison[ final_comparison['Season'] == target_season]
+    print('Season ', target_season, ' log loss: ', metrics.log_loss(temp['Result'], temp['Pred']))


### PR DESCRIPTION
### Summary

Calculating Offensive rating and Defensive Rating per season for each team (ie excluding the march madness games)

Feels free to double check the calculation since it might be wrong :laughing: 

I tried checking if the values are matching to other online source but it seem they include march madness games when calculating the possessions and rating

Previous output (calculating pos per game)
```
   Season  WTeamID  WScore  LScore     ORating     DRating
0    2003     1102    1603    1596  105.798118  105.336118
1    2003     1103    2127    2110  113.513101  112.605850
2    2003     1104    1940    1820  105.840624   99.293781
3    2003     1105    1866    1993   95.221207  101.701965
4    2003     1106    1781    1785   95.496735   95.711214
```

Current output (the advanced stats is all the way at the end)
```
                WScore  LTeamID  LScore  WFGM  WFGA  WFGM3  WFGA3  WFTM  WFTA  WOR  WDR  WAst  WTO  WStl  WBlk  WPF  LFGM  LFGA  LFGM3  LFGA3  LFTM  LFTA  LOR  LDR  LAst  LTO  LStl  LBlk  LPF          Pos     ORating     DRating
Season WTeamID                                                                                                                                                                                                                      
2003   1102       1603    36930    1596   536  1114    219    583   312   479  117  471   364  320   167    50  525   540  1188    133    348   383   539  269  564   256  363   152    44  514  1516.949514  105.672601  105.211148
       1103       2127    33977    2110   733  1508    147    434   514   698  264  538   411  341   196    63  536   750  1539    180    496   430   598  325  595   418  414   173    77  606  1873.805923  113.512289  112.605045
       1104       1940    35914    1820   673  1601    178    556   416   586  380  670   339  372   185   106  505   651  1554    178    536   340   480  305  634   327  388   155    89  539  1833.517252  105.807567   99.262769
       1105       1866    33024    1993   634  1602    197    540   401   568  351  601   378  485   242    54  526   702  1533    163    456   426   637  343  686   411  489   244   109  496  1958.671026   95.268678  101.752667
       1106       1781    34867    1785   656  1548    171    494   298   461  344  668   327  477   234    88  509   608  1495    134    426   435   615  317  626   330  422   246    89  452  1864.237504   95.535038   95.749603
```