### PR TITLE
Season games adv stats

### DIFF
--- a/advanced_stats_starter.py
+++ b/advanced_stats_starter.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 pd.set_option('display.max_rows', 500)
 pd.set_option('display.max_columns', 500)
@@ -47,6 +48,101 @@ def get_adv_season_stats():
     adv_stat_team_season = adv_stat_team_season.drop(['LTeamID'], axis=1)
     adv_stat_team_season = adv_stat_team_season.rename(columns={'WTeamID': 'TeamID'})
 
+    print(adv_stat_team_season.head())
+
     return adv_stat_team_season
 
-print(get_adv_season_stats().head())
+
+def get_adv_stats_per_season_game():
+    seasons_results = pd.read_csv("input/RegularSeasonDetailedResults.csv")
+    seasons_results = seasons_results.sort_values(['Season', 'DayNum'])
+
+    team_stats = {}
+    rating_per_game = pd.DataFrame()
+    print(seasons_results.shape)
+    print(rating_per_game.dtypes)
+    for index, row in seasons_results.iterrows():
+        # find rating for WTeamID first
+        print(index)
+        isCurrentSeason = seasons_results['Season'] == row.Season
+        isPrevGames = seasons_results['DayNum'] < row.DayNum
+        w_orating = 0.0
+        w_drating = 0.0
+        w_nrating = 0.0
+        w_four_factors = 0.0
+        l_orating = 0.0
+        l_drating = 0.0
+        l_nrating = 0.0
+        l_four_factors = 0.0
+
+        past_games = seasons_results[isCurrentSeason & isPrevGames]
+        if past_games.empty:
+            continue
+
+        past_games_copy = past_games.copy()
+        win_stats = ['WTeamID', 'WScore', 'WFGM', 'WFGA', 'WFGM3', 'WFGA3', 'WFTM', 'WFTA', 'WOR', 'WDR', 'WAst',
+                     'WTO', 'WStl', 'WBlk', 'WPF']
+        lose_stats = ['LTeamID', 'LScore', 'LFGM', 'LFGA', 'LFGM3', 'LFGA3', 'LFTM', 'LFTA', 'LOR', 'LDR', 'LAst',
+                      'LTO', 'LStl', 'LBlk', 'LPF']
+
+        past_games_copy[win_stats + lose_stats] = past_games_copy[lose_stats + win_stats]
+        past_games = pd.concat([past_games, past_games_copy], ignore_index=True)
+
+        past_games_groupby = past_games.groupby('WTeamID').sum().reset_index()
+        past_games_groupby['Pos'] = past_games_groupby.apply(get_pos, axis=1)
+        past_games_groupby['ORating'] = past_games_groupby.apply(lambda row: 100 * row.WScore / row.Pos, axis=1)
+        past_games_groupby['DRating'] = past_games_groupby.apply(lambda row: 100 * row.LScore / row.Pos, axis=1)
+        past_games_groupby['NRating'] = past_games_groupby['ORating'] - past_games_groupby['DRating']
+        past_games_groupby['FourFactors'] = past_games_groupby.apply(get_four_factor, axis=1)
+        past_games_groupby = past_games_groupby.drop(['LTeamID'], axis=1)
+        past_games_groupby = past_games_groupby.rename(columns={'WTeamID': 'TeamID'})
+
+        # helper function to retrieve the values
+        def get_adv_stats_for_team(team_row):
+            orating = team_row['ORating']
+            drating = team_row['DRating']
+            nrating = team_row['NRating']
+            four_factors = team_row['FourFactors']
+
+            # for some reason, sometime these value are actually Serie object !!! so have to do this
+            if not isinstance(orating, float):
+                orating = team_row['ORating'].values[0]
+                drating = team_row['DRating'].values[0]
+                nrating = team_row['NRating'].values[0]
+                four_factors = team_row['FourFactors'].values[0]
+
+            return orating, drating, nrating, four_factors
+
+        wteam_row = past_games_groupby[past_games_groupby['TeamID'] == row.WTeamID]
+        if not wteam_row.empty:
+            w_orating, w_drating, w_nrating, w_four_factors = get_adv_stats_for_team(wteam_row)
+
+        lteam_row = past_games_groupby[past_games_groupby['TeamID'] == row.LTeamID]
+        if not lteam_row.empty:
+            l_orating, l_drating, l_nrating, l_four_factors = get_adv_stats_for_team(lteam_row)
+
+        new_row = {
+            'Season': row.Season,
+            'DayNum': row.DayNum,
+            'WTeamID': row.WTeamID,
+            'LTeamID': row.LTeamID,
+            'WORating': w_orating,
+            'WDRating': w_drating,
+            'WNRating': w_nrating,
+            'WFourFactors': w_four_factors,
+            'LORating': l_orating,
+            'LDRating': l_drating,
+            'LNRating': l_nrating,
+            'LFourFactors': l_four_factors,
+
+        }
+        rating_per_game = rating_per_game.append(new_row, ignore_index=True)
+
+    # need to merge the rating back into the season game
+    seasons_results = seasons_results.merge(rating_per_game, on=['Season', 'DayNum', 'WTeamID', 'LTeamID'])
+
+    output_columns = ['Season', 'DayNum', 'WTeamID', 'LTeamID', 'LDRating',  'LFourFactors', 'LNRating', 'LORating',
+                      'WDRating', 'WFourFactors', 'WNRating', 'WORating']
+    seasons_results = seasons_results[output_columns]
+    print(seasons_results.tail())
+    # seasons_results.to_csv('seasons_results_adv_stats.csv', index=False)

--- a/pomeroy_rating_team_id.py
+++ b/pomeroy_rating_team_id.py
@@ -227,7 +227,7 @@ pomeroy_rating = pomeroy_rating.drop_duplicates(['Season', 'TeamID'])
 print(pomeroy_rating.head())
 print(pomeroy_rating.isnull().values.any())
 print(pomeroy_rating.loc[(pomeroy_rating['TeamID'] == 1107) & (pomeroy_rating['Season'] == 2015)])
-pomeroy_rating.to_csv('p_rating_with_team_id.csv', index=False)
+# pomeroy_rating.to_csv('p_rating_with_team_id.csv', index=False)
 
 
 

--- a/regular_season_rating_classifier.py
+++ b/regular_season_rating_classifier.py
@@ -1,0 +1,87 @@
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV
+import numpy as np
+from advanced_stats_starter import get_adv_season_stats
+from submission_simulation import simulate_submit
+
+pd.set_option('display.max_rows', 500)
+pd.set_option('display.max_columns', 500)
+pd.set_option('display.width', 1000)
+
+season_with_adv_stats = pd.read_csv("seasons_results_adv_stats.csv")
+submission = pd.read_csv("input/SampleSubmissionStage1.csv")
+adv_stat_team_season = get_adv_season_stats()
+
+# discard first half of the season
+season_with_adv_stats = season_with_adv_stats[season_with_adv_stats['DayNum'] >= 66]
+
+season_with_adv_stats = season_with_adv_stats.drop(['Season', 'DayNum', 'WTeamID', 'LTeamID'], axis=1)
+
+# dropping any rows that have a 0 value
+season_with_adv_stats = season_with_adv_stats[(season_with_adv_stats != 0).all(1)]
+
+print(season_with_adv_stats.head())
+
+season_with_adv_stats['Result'] = 1
+
+season_with_adv_stats_copy = season_with_adv_stats.copy()
+
+train_w_stat = ['WDRating', 'WFourFactors', 'WNRating', 'WORating']
+train_l_stat = ['LDRating', 'LFourFactors', 'LNRating', 'LORating']
+
+season_with_adv_stats_copy[train_w_stat + train_l_stat] = season_with_adv_stats_copy[train_l_stat + train_w_stat]
+season_with_adv_stats_copy['Result'] = 0
+
+season_with_adv_stats = pd.concat([season_with_adv_stats, season_with_adv_stats_copy], ignore_index=True)
+
+y_train = season_with_adv_stats['Result'].values
+X_train = season_with_adv_stats.drop('Result', axis=1)
+
+# this is just to try using NRating only as input
+# X_train = X_train.drop(['WDRating', 'LDRating', 'WORating', 'LORating', 'LFourFactors', 'WFourFactors'], axis=1)
+# print(X_train.head())
+
+logreg = LogisticRegression()
+params = {'C': np.logspace(start=-5, stop=3, num=9)}
+clf = GridSearchCV(logreg, params, scoring='neg_log_loss', refit=True)
+clf.fit(X_train, y_train)
+print('Best log_loss: {:.4}, with best C: {}'.format(clf.best_score_, clf.best_params_['C']))
+
+prediction = pd.DataFrame()
+prediction['Season'] = submission['ID'].str[:4].astype(int)
+prediction['WTeamID'] = submission['ID'].str[5:9].astype(int)
+prediction['LTeamID'] = submission['ID'].str[10:].astype(int)
+
+
+train_stats = ['Season', 'TeamID', 'ORating', 'DRating', 'NRating', 'FourFactors']
+win_adv_stats = adv_stat_team_season[train_stats].rename(columns={
+    'TeamID': 'WTeamID',
+    'NRating': 'WNRating',
+    'FourFactors': 'WFourFactors',
+    'ORating': 'WORating',
+    'DRating': 'WDRating'
+})
+
+lose_adv_stats = adv_stat_team_season[train_stats].rename(columns={
+    'TeamID': 'LTeamID',
+    'NRating': 'LNRating',
+    'FourFactors': 'LFourFactors',
+    'ORating': 'LORating',
+    'DRating': 'LDRating'
+})
+
+prediction = prediction.merge(lose_adv_stats, on=['Season', 'LTeamID'])
+prediction = prediction.merge(win_adv_stats, on=['Season', 'WTeamID'])
+
+reorder_col = ['WDRating', 'WFourFactors', 'WNRating', 'WORating', 'LDRating', 'LFourFactors', 'LNRating', 'LORating']
+# reorder_col = ['WNRating', 'LNRating']
+prediction = prediction.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
+
+# prediction = prediction.drop(['WDRating', 'LDRating', 'WORating', 'LORating', 'LFourFactors', 'WFourFactors'], axis=1)
+
+prediction = prediction[reorder_col]
+
+print(prediction.head())
+submission['Pred'] = clf.predict_proba(prediction)
+simulate_submit(submission)

--- a/simple_logistic_regression.py
+++ b/simple_logistic_regression.py
@@ -67,16 +67,21 @@ lose_adj = adj_adv_stat_team_season.rename(columns={
     'AdjNRating': 'LAdjNRating'
 })
 
-train = train.merge(win_adj, on=['Season', 'WTeamID'])
-train = train.merge(lose_adj, on=['Season', 'LTeamID'])
+# uncomment to use adj rating
+# train = train.merge(win_adj, on=['Season', 'WTeamID'])
+# train = train.merge(lose_adj, on=['Season', 'LTeamID'])
 
 train = train.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
 train['Result'] = 1
 
 train_copy = train.copy()
 
-train_w_stat = ['WORating', 'WDRating', 'WSeed', 'WAdjNRating']
-train_l_stat = ['LORating', 'LDRating', 'LSeed', 'LAdjNRating']
+train_w_stat = ['WORating', 'WDRating', 'WSeed']
+train_l_stat = ['LORating', 'LDRating', 'LSeed']
+
+# uncomment to use adj rating
+# train_w_stat.append('WAdjNRating')
+# train_l_stat.append('LAdjNRating')
 
 train_copy[train_w_stat + train_l_stat] = train_copy[train_l_stat + train_w_stat]
 train_copy['SeedDiff'] = -train_copy['SeedDiff']
@@ -86,7 +91,6 @@ train = pd.concat([train, train_copy], ignore_index=True)
 
 # Print to show training data used
 print(train.head(n=5))
-print(train.tail())
 
 y_train = train['Result'].values
 X_train = train.drop('Result', axis=1)
@@ -110,13 +114,14 @@ prediction = prediction.merge(win_adv_stats, on=['Season', 'WTeamID'])
 
 prediction = prediction.merge(lossseeds, on=['Season', 'LTeamID'])
 prediction = prediction.merge(winseeds, on=['Season', 'WTeamID'])
-prediction['SeedDiff'] = prediction.WSeed - prediction.LSeed
+prediction['SeedDiff'] = prediction.LSeed - prediction.WSeed
 
-prediction = prediction.merge(lose_adj, on=['Season', 'LTeamID'])
-prediction = prediction.merge(win_adj, on=['Season', 'WTeamID'])
+# Uncomment to use adj rating
+# prediction = prediction.merge(lose_adj, on=['Season', 'LTeamID'])
+# prediction = prediction.merge(win_adj, on=['Season', 'WTeamID'])
 
 prediction = prediction.drop(['Season', 'WTeamID', 'LTeamID'], axis=1)
-
+print(prediction.head())
 submission['Pred'] = clf.predict_proba(prediction)
 simulate_submit(submission)
 


### PR DESCRIPTION
### Summary 

- Added a function in adv stat script to generate rating per season games (takes around 2hour 30min to run)

- Created new a script to train the advanced stats per season game data 

```
Season  2014  log loss:  0.608148685396824
Season  2015  log loss:  0.5424249639428051
Season  2016  log loss:  0.6097675723202799
Season  2017  log loss:  0.5932382444248455
final log loss:  0.5883948665211886
````